### PR TITLE
SDKJS-38 Extend get payment fee rules

### DIFF
--- a/test/api/fixtures/reference.js
+++ b/test/api/fixtures/reference.js
@@ -180,7 +180,7 @@ nock('https://devapi.currencycloud.com:443', {"encodedQueryParams":true})
 
 nock('https://devapi.currencycloud.com:443', {"encodedQueryParams":true})
     .get('/v2/reference/payment_fee_rules')
-    .reply(200, {"payment_fee_rules": [{"payment_type": "priority","charge_type": "shared","fee_amount": "2.00","fee_currency": "AED"},{"payment_type": "regular","charge_type": "shared","fee_amount": "12.00","fee_currency": "USD"},{"payment_type": "priority","charge_type": "ours","fee_amount": "5.25","fee_currency": "GBP"}]}, [ 'Date',
+    .reply(200, {"payment_fee_rules": [{"payment_type": "priority","charge_type": "shared","fee_amount": "2.00","fee_currency": "AED", "payment_fee_id": "00000000-0000-0000-1111-000000000000", "payment_fee_name": "payment_fee_name_aed"},{"payment_type": "regular","charge_type": "shared","fee_amount": "12.00","fee_currency": "USD", "payment_fee_id": "00000000-0000-0000-2222-000000000000", "payment_fee_name": "payment_fee_name_usd"},{"payment_type": "priority","charge_type": "ours","fee_amount": "5.25","fee_currency": "GBP", "payment_fee_id": "00000000-0000-0000-3333-000000000000", "payment_fee_name": "payment_fee_name_gbp"}]}, [ 'Date',
       'Mon, 16 Jul 2018 16:24:27 GMT',
       'Content-Type',
       'application/json;charset=utf-8',

--- a/test/api/reference.js
+++ b/test/api/reference.js
@@ -165,14 +165,20 @@ describe('reference', function () {
                     expect(res.paymentFeeRules[0]).to.have.property('feeAmount').that.eql("2.00");
                     expect(res.paymentFeeRules[0]).to.have.property('feeCurrency').that.eql("AED");
                     expect(res.paymentFeeRules[0]).to.have.property('paymentType').that.eql("priority");
+                    expect(res.paymentFeeRules[0]).to.have.property('paymentFeeId').that.eql("00000000-0000-0000-1111-000000000000");
+                    expect(res.paymentFeeRules[0]).to.have.property('paymentFeeName').that.eql("payment_fee_name_aed");
                     expect(res.paymentFeeRules[1]).to.have.property('chargeType').that.eql("shared");
                     expect(res.paymentFeeRules[1]).to.have.property('feeAmount').that.eql("12.00");
                     expect(res.paymentFeeRules[1]).to.have.property('feeCurrency').that.eql("USD");
                     expect(res.paymentFeeRules[1]).to.have.property('paymentType').that.eql("regular");
+                    expect(res.paymentFeeRules[1]).to.have.property('paymentFeeId').that.eql("00000000-0000-0000-2222-000000000000");
+                    expect(res.paymentFeeRules[1]).to.have.property('paymentFeeName').that.eql("payment_fee_name_usd");
                     expect(res.paymentFeeRules[2]).to.have.property('chargeType').that.eql("ours");
                     expect(res.paymentFeeRules[2]).to.have.property('feeAmount').that.eql("5.25");
                     expect(res.paymentFeeRules[2]).to.have.property('feeCurrency').that.eql("GBP");
                     expect(res.paymentFeeRules[2]).to.have.property('paymentType').that.eql("priority");
+                    expect(res.paymentFeeRules[2]).to.have.property('paymentFeeId').that.eql("00000000-0000-0000-3333-000000000000");
+                    expect(res.paymentFeeRules[2]).to.have.property('paymentFeeName').that.eql("payment_fee_name_gbp");
                     done();
                 })
                 .catch(done);


### PR DESCRIPTION
"payment_fee_rules" now includes new fields for each rule:

payment_fee_name (return name of payment level fee table)
payment_fee_id (return id of Payment Level Rule Id)
Jira ticket:https://ccycloud.atlassian.net/browse/SDKJS-38