### PR TITLE
Change ../package imports to ../package.json

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,8 +7,8 @@
 var rp = require('request-promise');
 var error = require('./error');
 var utils = require('./utils');
-var settings = require('../package').settings;
-var version = require('../package').version;
+var settings = require('../package.json').settings;
+var version = require('../package.json').version;
 
 var config, token, onbehalfof;
 


### PR DESCRIPTION
When using webpack with this project with custom aliases, importing from `package` doesn't work. This way is more specific and doesn't rely on a certain (albeit default) webpack config.

My webpack extensions:
`extensions: ['.ts', '.tsx', '.mjs', '.js'],`