### PR TITLE
Add try/catch around error response JSON formatting 

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -32,8 +32,17 @@ class APIerror extends Error {
     };
     this.errors = [];
 
-    var errorMessages = utils.camelize(JSON.parse(err.error)).errorMessages;
-
+    var errorMessages;
+    try {
+       errorMessages = utils.camelize(JSON.parse(err.error)).errorMessages;
+    } catch (ex) {
+       errorMessages = {
+         base:{
+           code:'badly_formatted_error_response',
+           message:err.error
+         }
+       };
+    }
     for (var field of Object.keys(errorMessages)) {
       if (typeof errorMessages[field][Symbol.iterator] === 'function') {
         for (var fieldError of errorMessages[field]) {

--- a/lib/error.js
+++ b/lib/error.js
@@ -34,14 +34,14 @@ class APIerror extends Error {
 
     var errorMessages;
     try {
-       errorMessages = utils.camelize(JSON.parse(err.error)).errorMessages;
+      errorMessages = utils.camelize(JSON.parse(err.error)).errorMessages;
     } catch (ex) {
-       errorMessages = {
-         base:{
-           code:'badly_formatted_error_response',
-           message:err.error
-         }
-       };
+      errorMessages = {
+        base: {
+          code: 'badly_formatted_error_response',
+          message: err.error
+        }
+      };
     }
     for (var field of Object.keys(errorMessages)) {
       if (typeof errorMessages[field][Symbol.iterator] === 'function') {

--- a/test/api/error-test.js
+++ b/test/api/error-test.js
@@ -79,4 +79,81 @@ describe('apierror', function () {
         });
     });
 
+    describe('handle well formatted 500 error response', function () {
+        it('successfully respond with InternalApplicationError', function (done) {
+            currencyCloud.payments.create({
+                onBehalfOf: '4224b460-f6c3-4d4d-842f-67c5fbe5461b',
+                beneficiaryId: '0ebad221-e846-420a-8abc-9a4136b7a500',
+                currency: 'EUR',
+                amount: '1.00',
+                reason: 'Test Good Error Response',
+                paymentType: 'priority',
+                reference: '3a4bca96-8f59-4eef-bbfc-6592744609c3'
+            })
+                .then(function (res) {
+                    expect(res).is.empty;
+                    done();
+                })
+                .catch(function (res) {
+                        expect(res).is.not.empty;
+                    expect(res).is.instanceOf(currencyCloud.InternalApplicationError);
+                        done();
+                    }
+                );
+        });
+    });
+
+    describe('handle badly formatted 500 error response', function () {
+        it('successfully respond with InternalApplicationError again', function (done) {
+            currencyCloud.payments.create({
+                onBehalfOf: '4224b460-f6c3-4d4d-842f-67c5fbe5461b',
+                beneficiaryId: '0ebad221-e846-420a-8abc-9a4136b7a500',
+                currency: 'EUR',
+                amount: '1.00',
+                reason: 'Test Bad Error Response',
+                paymentType: 'priority',
+                reference: '53db7778-75a9-447d-baf0-d09deb9a4ba6'
+            })
+                .then(function (res) {
+                    expect(res).is.empty;
+                    done();
+                })
+                .catch(function (res) {
+                        expect(res).is.not.empty;
+                        expect(res).is.instanceOf(currencyCloud.InternalApplicationError);
+                        done();
+                    }
+                );
+        });
+    });
+
+    describe('handle really badly formatted 500 error response', function () {
+        it('successfully respond with InternalApplicationError one more time', function (done) {
+            currencyCloud.payments.create({
+                onBehalfOf: '4224b460-f6c3-4d4d-842f-67c5fbe5461b',
+                beneficiaryId: '0ebad221-e846-420a-8abc-9a4136b7a500',
+                currency: 'EUR',
+                amount: '1.00',
+                reason: 'Test Really Bad Error Response',
+                paymentType: 'priority',
+                reference: '99d5d977-0c6a-4d31-a328-e9e51384db45'
+            })
+                .then(function (res) {
+                    expect(res).is.empty;
+                    done();
+                })
+                .catch(function (res) {
+                        expect(res).is.not.empty;
+                        console.log("================ JON =============");
+                        console.log(res);
+                        console.log("================ JON =============");
+                        expect(res).is.instanceOf(currencyCloud.InternalApplicationError);
+                        expect(res.errors[0]).to.have.property('field').that.eql('base');
+                        expect(res.errors[0]).to.have.property('code').that.eql('badly_formatted_error_response');
+                        done();
+                    }
+                );
+        });
+    });
+
 });

--- a/test/api/error-test.js
+++ b/test/api/error-test.js
@@ -144,9 +144,6 @@ describe('apierror', function () {
                 })
                 .catch(function (res) {
                         expect(res).is.not.empty;
-                        console.log("================ JON =============");
-                        console.log(res);
-                        console.log("================ JON =============");
                         expect(res).is.instanceOf(currencyCloud.InternalApplicationError);
                         expect(res.errors[0]).to.have.property('field').that.eql('base');
                         expect(res.errors[0]).to.have.property('code').that.eql('badly_formatted_error_response');

--- a/test/api/fixtures/error-test.js
+++ b/test/api/fixtures/error-test.js
@@ -40,6 +40,64 @@ nock('https://devapi.currencycloud.com:443', {"encodedQueryParams":true})
         }
     }, [ 'Date','Thu, 18 Jun 2020 10:10:18 GMT','X-Request-Id', '887d4999-d021-4333-8593-34a3f27587dc']);
 
+nock('https://devapi.currencycloud.com:443')
+    .post('/v2/payments/create', {
+        "on_behalf_of": "4224b460-f6c3-4d4d-842f-67c5fbe5461b",
+        "beneficiary_id": "0ebad221-e846-420a-8abc-9a4136b7a500",
+        "currency": "EUR",
+        "amount": "1.00",
+        "reason": "Test Good Error Response",
+        "payment_type": "priority",
+        "reference": "3a4bca96-8f59-4eef-bbfc-6592744609c3"
+    })
+    .reply(500, {
+        "error_code":"missing_translation",
+        "error_messages":
+            {
+                "base":[
+                    {
+                        "code":"missing_translation",
+                        "message":"Sorry there is an internal error",
+                        "params":{}
+                    }
+                ]
+            }
+        }, [ 'Date','Thu, 24 Jun 2022 14:15:11 GMT','X-Request-Id', '95fbb651-42d4-429f-a74f-6e75ef06864f']);
+
+
+nock('https://devapi.currencycloud.com:443')
+    .post('/v2/payments/create', {
+        "on_behalf_of": "4224b460-f6c3-4d4d-842f-67c5fbe5461b",
+        "beneficiary_id": "0ebad221-e846-420a-8abc-9a4136b7a500",
+        "currency": "EUR",
+        "amount": "1.00",
+        "reason": "Test Bad Error Response",
+        "payment_type": "priority",
+        "reference": "53db7778-75a9-447d-baf0-d09deb9a4ba6"
+    })
+    .reply(500, {
+        "error_code":"internal_server_error",
+         "error_messages":{
+            "base":{
+                "code":"internal_server_error",
+                "message":"Internal Server Error"
+            }
+        }
+    }, [ 'Date','Thu, 24 Jun 2022 14:23:44 GMT','X-Request-Id', '4efab12e-b166-472e-9c9d-852943d4124c']);
+
+
+nock('https://devapi.currencycloud.com:443')
+    .post('/v2/payments/create', {
+        "on_behalf_of": "4224b460-f6c3-4d4d-842f-67c5fbe5461b",
+        "beneficiary_id": "0ebad221-e846-420a-8abc-9a4136b7a500",
+        "currency": "EUR",
+        "amount": "1.00",
+        "reason": "Test Really Bad Error Response",
+        "payment_type": "priority",
+        "reference": "99d5d977-0c6a-4d31-a328-e9e51384db45"
+    })
+    .reply(500, '{"error_code":"internal_server_error","error_messages":{"base":{"code":"internal_server_error","message":"Internal Server Err', [ 'Date','Thu, 24 Jun 2022 14:31:01 GMT','X-Request-Id', '9b722600-f511-484e-98f0-07a6d665e98f']);
+
 nock('https://devapi.currencycloud.com:443', {"encodedQueryParams":true})
     .post('/v2/authenticate/close_session')
     .reply(200, {});


### PR DESCRIPTION
Add try/catch around error response JSON formatting for the case when the error response body is not well formed JSON.

Not sure if this is the correct approach, but as we are not guaranteed JSON body error response, there should be a way of handling hat case