### PR TITLE
Adds endpoint to emulate inbound funds

### DIFF
--- a/lib/api/demo.js
+++ b/lib/api/demo.js
@@ -1,0 +1,36 @@
+/**
+ * @module demo
+ */
+
+"use strict";
+
+var client = require("../client");
+
+module.exports = {
+  /**
+   * Emulates inbound funds in demo environment
+   * @param {Object} params Object, which contains parameters to emulate inbound funds
+   * @param {String} params.id Id of account to be funded, required
+   * @return {Promise} Promise; if fulfilled returns object, which contains the newly created transaction, if rejected returns APIerror.
+   */
+  emulateInboundFunds: function (params) {
+    params = params || {};
+    const required = ["id", "receiverAccountNumber", "amount", "currency"];
+    required.forEach((prop) => {
+      if (params.hasOwnProperty(prop)) {
+        return;
+      }
+      throw new Error(`${prop} is required`);
+    });
+
+    var url = "/v2/demo/funding/create";
+
+    var promise = client.request({
+      url: url,
+      method: "POST",
+      qs: params,
+    });
+
+    return promise;
+  },
+};

--- a/lib/currency-cloud.js
+++ b/lib/currency-cloud.js
@@ -14,6 +14,7 @@ module.exports = {
   beneficiaries: require('./api/beneficiaries'),
   contacts: require('./api/contacts'),
   conversions: require('./api/conversions'),
+  demo: require('./api/demo'),
   funding: require('./api/funding'),
   ibans: require('./api/ibans'),
   payers: require('./api/payers'),

--- a/test/api/demo.js
+++ b/test/api/demo.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var currencyCloud = require("../../lib/currency-cloud");
+var expect = require("chai").expect;
+var mock = require("../mocks");
+var prepost = require("../prepost");
+var recorder = prepost.recorder("demo");
+var setup = prepost.setup;
+var teardown = prepost.teardown;
+
+describe("demo", function () {
+  before(function (done) {
+    recorder.read();
+    setup.login().then(function () {
+      done();
+    });
+  });
+
+  after(function (done) {
+    teardown.logout().then(function () {
+      recorder.write(done);
+    });
+  });
+
+  describe("emulateInboundFunds", function () {
+    it("fails if required parameters are missing", function () {
+      expect(function () {
+        currencyCloud.demo.emulateInboundFunds(/*no params*/);
+      }).to.throw();
+    });
+
+    it("successfully emulate inbound funds", function (done) {
+      currencyCloud.demo
+        .emulateInboundFunds(mock.emulates.emulate1())
+        .then(function (created) {
+          expect(mock.emulates.schema.validate(created)).is.true;
+          done();
+        })
+        .catch(done);
+    });
+  });
+});

--- a/test/api/fixtures/demo.js
+++ b/test/api/fixtures/demo.js
@@ -1,0 +1,13 @@
+var nock = require('nock');
+
+nock('https://devapi.currencycloud.com:443', {"encodedQueryParams": true})
+  .post('/v2/authenticate/api', "login_id=development%40currencycloud.com&api_key=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+  .reply(200, {"auth_token": "751786d0d27e0459dc6f6cc314d5d2ff"});
+
+nock('https://devapi.currencycloud.com:443', {"encodedQueryParams":true})
+  .post('/v2/demo/funding/create', "id=5dcfb283-dc5a-4c0d-b038-7ee8cd9ac643&receiver_account_number=0335017186&currency=USD&amount=12.5")
+  .reply(200, {"id":"5dcfb283-dc5a-4c0d-b038-7ee8cd9ac643","account_id":"67935c50-59ad-4d58-9edd-2be0ad3931b4","state":"pending","sender_name":"Test sender","sender_address":null,"sender_country":null,"sender_reference":null,"sender_account_number":null,"sender_routing_code":null,"receiver_account_number":"0335017186","receiver_routing_code":null,"amount":"12.50","currency":"USD","action":"approve","short_reference":"IF-20221212-TMT8VU","created_at":"2022-12-12T19:02:13+00:00","updated_at":"2022-12-12T19:02:13+00:00"});
+
+nock('https://devapi.currencycloud.com:443', {"encodedQueryParams":true})
+  .post('/v2/authenticate/close_session')
+  .reply(200, {});

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -315,6 +315,36 @@ module.exports = {
         })
     },
 
+    emulates: {
+        emulate1: function () {
+            return {
+                id: '5dcfb283-dc5a-4c0d-b038-7ee8cd9ac643',
+                receiverAccountNumber: '0335017186',
+                currency: 'USD',
+                amount: 12.5
+            };
+        },
+        schema: new JSONschema({
+            id: 'UUID',
+            accountId: 'UUID',
+            state: 'string',
+            senderName: 'string',
+            senderAddress: 'string',
+            senderCountry: 'string',
+            senderReference: 'string',
+            senderAccountNumber: 'string',
+            senderRoutingCode: 'number',
+            receiverAccountNumber: 'string',
+            receiverRoutingCode: 'string',
+            amount: 'number',
+            currency: 'string',
+            action: 'string',
+            shortReference: 'string',
+            createdAt: 'date',
+            updatedAt: 'date'
+        }),
+    },
+
     ibans: {
         schema: new JSONschema({
             id: 'UUID',


### PR DESCRIPTION
Add the following endpoint to [emulate inbound funds](https://developer.currencycloud.com/api-reference/#emulate-inbound-funds):

* POST /v2/demo/funding/create

This is very useful for testing purposes and allows developers to take advantage of the sdk features used for other endpoints.