### PR TITLE
Implement lazy login

### DIFF
--- a/lib/api/authentication.js
+++ b/lib/api/authentication.js
@@ -13,9 +13,10 @@ module.exports = {
    * @param {String} params.environment Environment to run against, one of those listed in 'settings' section of package.json, required
    * @param {String} params.loginId     Login id of the API user, required
    * @param {String} params.apiKey      API key of the API user, required   
+   * @param {Bool} lazy                 Store authentication config without requesting a token
    * @return {Promise}                  Promise; if fulfilled returns authentication token; if rejected returns APIerror.
    */
-  login: function (params) {
+  login: function (params, lazy) {
     params = params || {};
     if(!params.hasOwnProperty('environment')) {
       throw new Error('environment is required');
@@ -34,7 +35,7 @@ module.exports = {
       loginId: params.loginId,
       apiKey: params.apiKey,
       authUrl: url
-    });
+    }, lazy);
 
     return promise;
   },

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,7 +48,7 @@ module.exports = {
     }
   },
 
-  authenticate: function (params) {
+  authenticate: function (params, lazy) {
     var baseUrl = settings.environment[params.environment];
     if (!baseUrl) {
       throw new Error('invalid environment');
@@ -61,6 +61,10 @@ module.exports = {
       authUrl: params.authUrl
     };
 
+    if (lazy) {
+      return Promise.resolve();
+    }
+
     var promise = requestToken()
       .catch(function (res) {
         throw new error(res);
@@ -70,6 +74,13 @@ module.exports = {
   },
 
   request: function (params) {
+    var checkToken = function () {
+      if (token) {
+        return Promise.resolve();
+      }
+      return requestToken();
+    };
+
     var reauthenticate = function (attempts) {
       var promise = requestToken()
         .catch(function (res) {
@@ -110,8 +121,8 @@ module.exports = {
       return promise;
     };
 
-    var promise = request(params)
-      .catch(function (res) {
+    var promise = checkToken().then(() =>
+      request(params).catch(function (res) {
         if (res.statusCode === 401 && token) {
           return reauthenticate(3)
             .then(function () {
@@ -124,7 +135,8 @@ module.exports = {
         else {
           throw new error(res);
         }
-      });
+      })
+    );
 
     return promise;
   },

--- a/test/api/authentication.js
+++ b/test/api/authentication.js
@@ -83,6 +83,24 @@ describe('authentication', function() {
       .then(done)
       .catch(done);
     });
+
+    it('successfully saves config with lazy login', function(done) {
+      currencyCloud.authentication.login(mock.credentials, true)
+      .then(function(token) {
+        expect(token).is.undefined;
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('persists authentication config and so can make a subsequent API call', function(done) {
+      currencyCloud.authentication.login(mock.credentials, true)
+      .then(currencyCloud.accounts.getCurrent)
+      .then(currencyCloud.authentication.logout)      
+      .then(done)
+      .catch(done);
+    });
+    
   });
 
   describe('logout', function() {

--- a/test/api/fixtures/authentication.js
+++ b/test/api/fixtures/authentication.js
@@ -42,6 +42,20 @@ nock('https://devapi.currencycloud.com:443')
   .post('/v2/authenticate/api', {
     "login_id":"development@currencycloud.com","api_key":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
   })
+  .reply(200, {"auth_token":"c2d3075c773f20fe45dc914d83fc913d"});
+
+nock('https://devapi.currencycloud.com:443')
+  .get('/v2/accounts/current')
+  .reply(200, {"id":"3a7d2f90-ae1f-493c-a8d6-26ad43700259","account_name":"Currencycloud","brand":"currencycloud","your_reference":null,"status":"enabled","street":null,"city":null,"state_or_province":null,"country":null,"postal_code":null,"spread_table":"fxcg_rfx_default","legal_entity_type":null,"created_at":"2017-10-30T13:46:49+00:00","updated_at":"2017-10-30T13:52:32+00:00","identification_type":null,"identification_value":null,"short_reference":"151030-00006"});
+
+nock('https://devapi.currencycloud.com:443')
+  .post('/v2/authenticate/close_session')
+  .reply(200, {});
+
+nock('https://devapi.currencycloud.com:443')
+  .post('/v2/authenticate/api', {
+    "login_id":"development@currencycloud.com","api_key":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  })
   .reply(200, {"auth_token":"439c7a366dede548bb1878dc4045bc60"});
 
 nock('https://devapi.currencycloud.com:443')


### PR DESCRIPTION
A common pattern for serverless data sources is to initialize authentication configuration (login id, api key), and subsequently invoke api requests as needed:

1. service initializes (login)
2. users performs requests as needed
3. service ends (logout)

Today the currency cloud sdk immediately sends an authentication request on step 1, which returns a token that can be used for a period of time (30 minutes). However, in many occasions there may be a significant period of time between step 1 and step 2... which means that we executed an unnecessary authentication request. For a number of reasons, it would be nice if the sdk could support a lazy login, like this:

1. service initializes (lazy login just stores config without making authentication request)
2. user performs initial request (sdk does not have a token, so it authenticates before sending the request)
3. users continue to execute requests using the token from step 2
4. service ends (logout)

This PR implements the lazy login pattern, by exposing a new optional argument to the authentication.login() function.